### PR TITLE
cicd: install before lint

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,13 +14,13 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.22"
+      - name: Install dependencies
+        run: go mod download
       - name: Setup golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
           version: v2.0
           args: --timeout=5m
-      - name: Install dependencies
-        run: go mod download
       - name: Run tests
         run: go test ./...
       - name: Prepare/Release Workflows Check


### PR DESCRIPTION
This pull request includes a minor reordering of steps in the `.github/workflows/test.yaml` file. The change moves the installation of dependencies to occur before setting up `golangci-lint`.

* [`.github/workflows/test.yaml`](diffhunk://#diff-245392b692a50c38ecab4381b118862db514035c10983f3bd4f4b7f1f4be4692R17-L23): Moved the `Install dependencies` step to occur before the `Setup golangci-lint` step.