### PR TITLE
chore(deps): dependabot sweep 2026-03-31

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -325,6 +325,13 @@ When working with documentation:
 - **Reference**: Complete technical specifications and API documentation
 - **Development**: Contributor-focused technical documentation
 
+### Changelog (`Changes.md`)
+- Headings must be either `## <version-tag>  <date>` (e.g., `## v1.0.0-rc6  2025-11-17`) or `## WIP  TBD` for unreleased changes. No other heading format is acceptable.
+- Entries describe what changed, not process. Use the pattern from existing entries: ` * Updated <package> to <version>`, ` * Added ...`, ` * Fixed ...`, etc.
+- Never record things that didn't happen (e.g., skipped PRs, failed merges). A changelog records changes, not non-changes.
+- Follow the existing bullet style: ` * ` (space-asterisk-space) with one leading space.
+- For feature entries, use `* **Short Phrase**: Description` with sub-bullets indented four spaces.
+
 ### Writing Style
 - Use clear, concise language appropriate for technical audiences
 - Include code examples with proper syntax highlighting

--- a/Changes.md
+++ b/Changes.md
@@ -1,8 +1,7 @@
-## Dependabot Sweep  2026-03-31
+## WIP  TBD
 
-* **Merged**: Merged Dependabot PR #75: chore(deps): bump github.com/pelletier/go-toml/v2 from 2.2.4 to 2.3.0
-* **Merged**: Merged Dependabot PR #76: chore(deps): bump actions/deploy-pages from 4 to 5
-* **Skipped**: PR #77 (chore(deps): bump actions/configure-pages from 5 to 6) has failing checks
+ * Updated github.com/pelletier/go-toml/v2 to v2.3.0
+ * Updated actions/deploy-pages to v5
 
 ## v1.0.0-rc6  2025-11-17
 

--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,9 @@
+## Dependabot Sweep  2026-03-31
+
+* **Merged**: Merged Dependabot PR #75: chore(deps): bump github.com/pelletier/go-toml/v2 from 2.2.4 to 2.3.0
+* **Merged**: Merged Dependabot PR #76: chore(deps): bump actions/deploy-pages from 4 to 5
+* **Skipped**: PR #77 (chore(deps): bump actions/configure-pages from 5 to 6) has failing checks
+
 ## v1.0.0-rc6  2025-11-17
 
 * **Output Mode Support**: Flexible output formatting for different use cases and environments


### PR DESCRIPTION
## Summary

- Merged Dependabot PR #75: bump github.com/pelletier/go-toml/v2 from 2.2.4 to 2.3.0
- Merged Dependabot PR #76: bump actions/deploy-pages from 4 to 5
- Updated changelog with sweep results

## Skipped

- PR #77 (bump actions/configure-pages from 5 to 6) — failing checks, not investigated

## Vulnerability Alerts

- Dependabot alerts not accessible (not enabled or insufficient token permissions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)