### PR TITLE
chore(deps): dependabot sweep 2026-04-13

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -2,6 +2,7 @@
 
  * Updated github.com/pelletier/go-toml/v2 to v2.3.0
  * Updated actions/deploy-pages to v5
+ * Updated actions/configure-pages to v6
 
 ## v1.0.0-rc6  2025-11-17
 


### PR DESCRIPTION
## Summary

### Merged
- Merged Dependabot PR #77: chore(deps): bump actions/configure-pages from 5 to 6

### Vulnerability Alerts
- No open alerts

### Changelog
- Updated `Changes.md` with merged dependency update

🤖 Generated with [Claude Code](https://claude.com/claude-code)