### PR TITLE
chore(deps): dependabot sweep 2026-04-20

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -3,6 +3,7 @@
  * Updated github.com/pelletier/go-toml/v2 to v2.3.0
  * Updated actions/deploy-pages to v5
  * Updated actions/configure-pages to v6
+ * Updated actions/upload-pages-artifact to v5
 
 ## v1.0.0-rc6  2025-11-17
 


### PR DESCRIPTION
## Summary

Dependabot maintenance sweep for 2026-04-20.

### Merged
- Merged Dependabot PR #81: chore(deps): bump actions/upload-pages-artifact from 4 to 5

### Changelog
- Added entry for `actions/upload-pages-artifact` v5 to the `## WIP  TBD` section of `Changes.md`.

No vulnerability alerts were open. No conflicting or failing-check PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)