### PR TITLE
chore(deps): dependabot sweep 2026-05-11

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,7 @@
 ## WIP  TBD
 
  * Updated github.com/pelletier/go-toml/v2 to v2.3.0
+ * Updated github.com/pelletier/go-toml/v2 to v2.3.1
  * Updated actions/deploy-pages to v5
  * Updated actions/configure-pages to v6
 

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,5 @@
 ## WIP  TBD
 
- * Updated github.com/pelletier/go-toml/v2 to v2.3.0
  * Updated github.com/pelletier/go-toml/v2 to v2.3.1
  * Updated actions/deploy-pages to v5
  * Updated actions/configure-pages to v6


### PR DESCRIPTION
## Summary

Dependabot maintenance sweep for 2026-05-11.

### Merged
- Merged Dependabot PR #84: chore(deps): bump github.com/pelletier/go-toml/v2 from 2.3.0 to 2.3.1

### Changelog
- Updated `Changes.md` with the merged update under the WIP section.

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)