### PR TITLE
chore(deps): dependabot sweep 2026-07-20

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 0
           
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
           

--- a/.github/workflows/prepare.yaml
+++ b/.github/workflows/prepare.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v7
         with:
             go-version: '1.25'
       - name: Release Version

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v7
         with:
           go-version: '1.25'
       - name: Release Version

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version: "1.25"
       - name: Install dependencies

--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,7 @@
 ## WIP  TBD
 
+ * Updated actions/setup-python to v7
+ * Updated actions/setup-go to v7
  * Updated github.com/pelletier/go-toml/v2 to v2.4.3
  * Updated github.com/pelletier/go-toml/v2 to v2.4.2
  * Updated actions/checkout to v7


### PR DESCRIPTION
Weekly Dependabot sweep.

## PRs batch-merged
- Closes #94 — chore(deps): bump actions/setup-python from 6 to 7
- Closes #95 — chore(deps): bump actions/setup-go from 6 to 7

## Vulnerabilities fixed
None (no open Dependabot alerts).

## Changelog
Updated `Changes.md` under `## WIP  TBD`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)